### PR TITLE
20-add-details-page-for-projects

### DIFF
--- a/src/components/DateSubtitle.astro
+++ b/src/components/DateSubtitle.astro
@@ -1,0 +1,13 @@
+---
+interface Props {
+    startDate: Date, 
+    endDate?: Date,
+}
+
+const {startDate, endDate} = Astro.props;
+const dateOptions: Intl.DateTimeFormatOptions = { month: "short", year: "numeric", day: "numeric"};
+const startDateFormatStr = startDate.toLocaleDateString(undefined, dateOptions);
+const endDateFormatStr = endDate?.toLocaleDateString(undefined, dateOptions) ?? "Present";
+---
+
+<sub>{startDateFormatStr} - {endDateFormatStr}</sub>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -11,10 +11,10 @@ const { iconPath } = Astro.props;
 <nav>
     <a id="LogoLink" href="#Header"><b><img src={iconPath} alt="Jeanette Crull"  /></b></a>
     <ul class="DestOpts">
-        <NavLinks dest="#About" label="About" />
-        <NavLinks dest="#ProfessionalExperience" label="Experience" />
-        <NavLinks dest="#Projects" label="Projects" />
-        <NavLinks dest="#ContactInfo" label="Contact" emphasized={true}/>
+        <NavLinks dest="/Portfolio/index.html#About" label="About" />
+        <NavLinks dest="/Portfolio/index.html#ProfessionalExperience" label="Experience" />
+        <NavLinks dest="/Portfolio/index.html#Projects" label="Projects" />
+        <NavLinks dest="/Portfolio/index.html#ContactInfo" label="Contact" emphasized={true}/>
     </ul>
 </nav>
 

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,7 +9,7 @@ const { iconPath } = Astro.props;
 ---
 
 <nav>
-    <a id="LogoLink" href="#Header"><b><img src={iconPath} alt="Jeanette Crull"  /></b></a>
+    <a id="LogoLink" href="/Portfolio/index.html#Header"><b><img src={iconPath} alt="Jeanette Crull"  /></b></a>
     <ul class="DestOpts">
         <NavLinks dest="/Portfolio/index.html#About" label="About" />
         <NavLinks dest="/Portfolio/index.html#ProfessionalExperience" label="Experience" />

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,6 +1,7 @@
 ---
 import "../styles/colorPalette.css"
 import { Image } from "astro:assets"
+import DateSubtitle from "./DateSubtitle.astro";
 interface Props {
     projImage: string;
     imageAltText: string;
@@ -9,15 +10,12 @@ interface Props {
     completionDate?: Date;
 }
 const { projImage, imageAltText, projectName, startDate, completionDate } = Astro.props;
-const dateOptions: Intl.DateTimeFormatOptions = { month: "short", year: "numeric"}
-const startDateFormatStr = startDate.toLocaleDateString(undefined, dateOptions)
-const completionDateFormatStr = completionDate?.toLocaleDateString(undefined, dateOptions) ?? "Present"
 ---
 <div class="ProjectCard">
     <Image src={ projImage } alt={ imageAltText } width={800} height={450}/>
     <div class="ProjectDesc">
         <h2>{ projectName }</h2>
-        <sub>{ startDateFormatStr } - { completionDateFormatStr }</sub>
+        <DateSubtitle startDate={startDate} endDate={completionDate}/>
         <p>
             <slot />
         </p>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -8,8 +8,10 @@ interface Props {
     projectName: string;
     startDate: Date;
     completionDate?: Date;
+    detailsLink?: string
 }
-const { projImage, imageAltText, projectName, startDate, completionDate } = Astro.props;
+const { projImage, imageAltText, projectName, startDate, completionDate, detailsLink} = Astro.props;
+const showDetailsLink = !(detailsLink === undefined)
 ---
 <div class="ProjectCard">
     <Image src={ projImage } alt={ imageAltText } width={800} height={450}/>
@@ -19,6 +21,12 @@ const { projImage, imageAltText, projectName, startDate, completionDate } = Astr
         <p>
             <slot />
         </p>
+        {showDetailsLink && 
+            <a href={detailsLink} class="detailsLink">
+                <p>Click here for more details.</p>
+            </a>
+        }
+        
     </div>
 </div>
 <style>
@@ -52,5 +60,8 @@ const { projImage, imageAltText, projectName, startDate, completionDate } = Astr
         object-fit: contain;
         width: 100%;
         height: fit-content;
+    }
+    .detailsLink {     
+        color: var(--highlight-purple);
     }
 </style>

--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -4,18 +4,37 @@ import ProjectCard from "./ProjectCard.astro"
 ---
 
 <div class="AlternatingCards">
-    <ProjectCard projImage="/Portfolio/LanPartyApp.png" imageAltText="LAN Party App" projectName="LAN Party App" startDate={new Date(2020, 8)} completionDate={new Date(2020, 11)} >
+    <ProjectCard 
+        projImage="/Portfolio/LanPartyApp.png" 
+        imageAltText="LAN Party App" 
+        projectName="LAN Party App" 
+        startDate={new Date(2020, 8)} 
+        completionDate={new Date(2020, 11)} >
         A webapp where players could create and find local game events. They could share what games are going to be played, 
         who was planning on attending, and what people should bring. 
     </ProjectCard>
-    <ProjectCard projImage="/Portfolio/Godot.png" imageAltText="Game" projectName="Untitled Godot Game" startDate={new Date(2024, 0)} detailsLink="/Portfolio/projects/GodotGame.html">
+    <ProjectCard 
+        projImage="/Portfolio/Godot.png" 
+        imageAltText="Game" 
+        projectName="Untitled Godot Game" 
+        startDate={new Date(2024, 0)} 
+        detailsLink="/Portfolio/projects/GodotGame.html">
         A board game video game built in Godot using C#. Players move around the board to complete jobs and buy properties for money,
         all to be the richest person in the end.
     </ProjectCard>
-    <ProjectCard projImage="/Portfolio/Dayta.png" imageAltText="Dayta Calendar" projectName="Dayta" startDate={new Date(2024, 3)}>
+    <ProjectCard 
+        projImage="/Portfolio/Dayta.png" 
+        imageAltText="Dayta Calendar" 
+        projectName="Dayta" 
+        startDate={new Date(2024, 3)}>
         A calendar app that I started developing with <a href="https://zoezo.dev/">Zoey Eijgenberger</a>. 
     </ProjectCard>
-    <ProjectCard projImage="/Portfolio/DivisibilityClock.png" imageAltText="Divisibility Clock" projectName="Divisibility Clock" startDate={new Date(2024, 6, 25)} completionDate={new Date(2024, 6, 26)}>
+    <ProjectCard 
+        projImage="/Portfolio/DivisibilityClock.png" 
+        imageAltText="Divisibility Clock" 
+        projectName="Divisibility Clock" 
+        startDate={new Date(2024, 6, 25)} 
+        completionDate={new Date(2024, 6, 26)}>
         A web app that generates diagrams to represent modular arithmatic patterns. It can be found <a href="https://betonjeanette.github.io/DivisibilityClock/">by following this link</a>.
     </ProjectCard>
 </div>

--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -8,6 +8,7 @@ import ProjectCard from "./ProjectCard.astro"
         projImage="/Portfolio/LanPartyApp.png" 
         imageAltText="LAN Party App" 
         projectName="LAN Party App" 
+        detailsLink="/Portfolio/projects/LanPartyApp.html"
         startDate={new Date(2020, 8)} 
         completionDate={new Date(2020, 11)} >
         A webapp where players could create and find local game events. They could share what games are going to be played, 

--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -8,7 +8,7 @@ import ProjectCard from "./ProjectCard.astro"
         A webapp where players could create and find local game events. They could share what games are going to be played, 
         who was planning on attending, and what people should bring. 
     </ProjectCard>
-    <ProjectCard projImage="/Portfolio/Godot.png" imageAltText="Game" projectName="Untitled Godot Game" startDate={new Date(2024, 0)}>
+    <ProjectCard projImage="/Portfolio/Godot.png" imageAltText="Game" projectName="Untitled Godot Game" startDate={new Date(2024, 0)} detailsLink="/Portfolio/projects/GodotGame.html">
         A board game video game built in Godot using C#. Players move around the board to complete jobs and buy properties for money,
         all to be the richest person in the end.
     </ProjectCard>

--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -34,6 +34,7 @@ import ProjectCard from "./ProjectCard.astro"
         projImage="/Portfolio/DivisibilityClock.png" 
         imageAltText="Divisibility Clock" 
         projectName="Divisibility Clock" 
+        detailsLink="/Portfolio/projects/DivisibilityClock.html"
         startDate={new Date(2024, 6, 25)} 
         completionDate={new Date(2024, 6, 26)}>
         A web app that generates diagrams to represent modular arithmatic patterns. It can be found <a href="https://betonjeanette.github.io/DivisibilityClock/">by following this link</a>.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,17 +27,6 @@ const { title } = Astro.props;
 	</body>
 </html>
 <style is:global>
-	:root {
-		--accent: 136, 58, 234;
-		--accent-light: 224, 204, 250;
-		--accent-dark: 49, 10, 101;
-		--accent-gradient: linear-gradient(
-			45deg,
-			rgb(var(--accent)),
-			rgb(var(--accent-light)) 30%,
-			white 60%
-		);
-	}
 	html {
 		font-family: system-ui, sans-serif;
 		background: #13151a;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,7 +21,9 @@ const { title } = Astro.props;
 	</head>
 	<body>
 		<Nav />
-		<slot />
+		<main>
+			<slot />
+		</main>
 	</body>
 </html>
 <style is:global>
@@ -53,5 +55,18 @@ const { title } = Astro.props;
 			Bitstream Vera Sans Mono,
 			Courier New,
 			monospace;
+	}
+	main {
+		margin: auto;
+		padding: 4px;
+		width: 800px;
+		max-width: calc(100% - 2rem);
+		color: white;
+		font-size: 20px;
+		line-height: 1.6;
+	}
+	body {
+		display: contents;
+		margin: 0;
 	}
 </style>

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -1,0 +1,62 @@
+---
+import Image from "astro/components/Image.astro";
+import Nav from "../components/Nav.astro"
+import "../styles/colorPalette.css"
+
+interface Props {
+    title: string,
+	imagePath: string
+};
+
+const { title, imagePath } = Astro.props;
+
+---
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="description" content="This is the portfolio website for Jeanette Crull." />
+		<meta name="author" content="Jeanette Crull" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>{title}</title>
+    </head>
+</html>
+<body>
+	<Nav />
+	<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
+	<h1>{title}</h1>
+	<slot />
+</body>
+<style is:global>
+	:root {
+		--accent: 136, 58, 234;
+		--accent-light: 224, 204, 250;
+		--accent-dark: 49, 10, 101;
+		--accent-gradient: linear-gradient(
+			45deg,
+			rgb(var(--accent)),
+			rgb(var(--accent-light)) 30%,
+			white 60%
+		
+		);
+	}
+	html {
+		font-family: system-ui, sans-serif;
+		background: #13151a;
+		background-size: 224px;
+		scroll-behavior: smooth;
+		scroll-padding-top: 80px;
+	}
+	code {
+		font-family:
+			Menlo,
+			Monaco,
+			Lucida Console,
+			Liberation Mono,
+			DejaVu Sans Mono,
+			Bitstream Vera Sans Mono,
+			Courier New,
+			monospace;
+	}
+</style>

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -27,8 +27,8 @@ const { title, imagePath, startDate, endDate } = Astro.props;
 <body>
 	<Nav />
 	<main>
-		<DateSubtitle startDate={startDate} endDate={endDate}>
 		<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
+		<DateSubtitle startDate={startDate} endDate={endDate} />
 		<h1>{title}</h1>
 		<slot />
 	</main>

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -34,18 +34,6 @@ const { title, imagePath, startDate, endDate } = Astro.props;
 	</main>
 </body>
 <style is:global>
-	:root {
-		--accent: 136, 58, 234;
-		--accent-light: 224, 204, 250;
-		--accent-dark: 49, 10, 101;
-		--accent-gradient: linear-gradient(
-			45deg,
-			rgb(var(--accent)),
-			rgb(var(--accent-light)) 30%,
-			white 60%
-		
-		);
-	}
 	html {
 		font-family: system-ui, sans-serif;
 		background: #13151a;

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -34,6 +34,12 @@ const { title, imagePath, startDate, endDate } = Astro.props;
 	</main>
 </body>
 <style is:global>
+	:root{
+		--border-width: 5px;
+        --border-radius: 30px;
+        --inside-border-radius: calc(var(--border-radius) - var(--border-width));
+        --padding: calc(2 * var(--border-width));
+	}
 	html {
 		font-family: system-ui, sans-serif;
 		background: #13151a;
@@ -64,5 +70,17 @@ const { title, imagePath, startDate, endDate } = Astro.props;
 	body {
 		display: contents;
 		margin: 0;
+	}
+	.projectPicture{
+		border-radius: var(--inside-border-radius) ;
+        object-fit: contain;
+        width: 100%;
+        height: fit-content;
+		width: min(800px, 100%);
+		border-radius: var(--border-radius);
+        border-width: var(--border-width);
+        border-color: var(--highlight-purple);
+        border-style: solid;
+		box-shadow: var(--border-width) var(--border-width);
 	}
 </style>

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -2,14 +2,16 @@
 import Image from "astro/components/Image.astro";
 import Nav from "../components/Nav.astro"
 import "../styles/colorPalette.css"
+import DateSubtitle from "../components/DateSubtitle.astro";
 
 interface Props {
     title: string,
-	imagePath: string
+	imagePath: string,
+	startDate: Date,
+	endDate?: Date,
 };
 
-const { title, imagePath } = Astro.props;
-
+const { title, imagePath, startDate, endDate } = Astro.props;
 ---
 <!doctype html>
 <html lang="en">
@@ -25,6 +27,7 @@ const { title, imagePath } = Astro.props;
 <body>
 	<Nav />
 	<main>
+		<DateSubtitle startDate={startDate} endDate={endDate}>
 		<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
 		<h1>{title}</h1>
 		<slot />

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -28,8 +28,8 @@ const { title, imagePath, startDate, endDate } = Astro.props;
 	<Nav />
 	<main>
 		<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
-		<DateSubtitle startDate={startDate} endDate={endDate} />
 		<h1>{title}</h1>
+		<DateSubtitle startDate={startDate} endDate={endDate} />
 		<slot />
 	</main>
 </body>

--- a/src/layouts/ProjectDetailsLayout.astro
+++ b/src/layouts/ProjectDetailsLayout.astro
@@ -24,9 +24,11 @@ const { title, imagePath } = Astro.props;
 </html>
 <body>
 	<Nav />
-	<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
-	<h1>{title}</h1>
-	<slot />
+	<main>
+		<Image class={"projectPicture"} src={imagePath} height={ 450 } width={ 800 } alt={ title }/>
+		<h1>{title}</h1>
+		<slot />
+	</main>
 </body>
 <style is:global>
 	:root {
@@ -58,5 +60,18 @@ const { title, imagePath } = Astro.props;
 			Bitstream Vera Sans Mono,
 			Courier New,
 			monospace;
+	}	
+	main {
+		margin: auto;
+		padding: 4px;
+		width: 800px;
+		max-width: calc(100% - 2rem);
+		color: white;
+		font-size: 20px;
+		line-height: 1.6;
+	}
+	body {
+		display: contents;
+		margin: 0;
 	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,41 +7,27 @@ import Contact from '../components/Contact.astro';
 ---
 
 <Layout title="Jeanette Crull">
-	<main>
-		<Header />
-		<MainPageSection id="About" label="About Me">
-			<p>
-				I am a full-stack software engineer currently based in Madison, Wisconsin.
-			</p>
-		</MainPageSection>
-		<MainPageSection id="ProfessionalExperience" label="Professional Experience">
-			<h2>Epic Systems</h2>
-			<p>Oct 2022 - Dec 2023</p>
-			<p>I was a full-stack developer on the Hospital Billing module of Epic, primarily in the insurance space.</p>
-		</MainPageSection>
-		<MainPageSection id="Projects" label="Projects">
-			<ProjectsSection />
-		</MainPageSection>
-		<MainPageSection id="Contact" label="Contact Information">
-			<Contact />
-		</MainPageSection>
-	</main>
+	<Header />
+	<MainPageSection id="About" label="About Me">
+		<p>
+			I am a full-stack software engineer currently based in Madison, Wisconsin.
+		</p>
+	</MainPageSection>
+	<MainPageSection id="ProfessionalExperience" label="Professional Experience">
+		<h2>Epic Systems</h2>
+		<p>Oct 2022 - Dec 2023</p>
+		<p>I was a full-stack developer on the Hospital Billing module of Epic, primarily in the insurance space.</p>
+	</MainPageSection>
+	<MainPageSection id="Projects" label="Projects">
+		<ProjectsSection />
+	</MainPageSection>
+	<MainPageSection id="Contact" label="Contact Information">
+		<Contact />
+	</MainPageSection>
 </Layout>
 
 <style>
-	main {
-		margin: auto;
-		padding: 4px;
-		width: 800px;
-		max-width: calc(100% - 2rem);
-		color: white;
-		font-size: 20px;
-		line-height: 1.6;
-	}
-	body {
-		display: contents;
-		margin: 0;
-	}
+
 	.astro-a {
 		position: absolute;
 		top: -32px;

--- a/src/pages/projects/DivisibilityClock.astro
+++ b/src/pages/projects/DivisibilityClock.astro
@@ -1,0 +1,22 @@
+---
+import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
+
+
+---
+<ProjectDetailsLayout title="Divisibility Clock" imagePath="/Portfolio/DivisibilityClock.png" startDate={new Date(2024, 5, 25)} endDate={new Date(2024, 5, 26)}>
+    <section>
+        <h2>What is this project?</h2>
+        <p>
+            This is a web app that creates diagrams for how, for a given divisor, a number's remainder will change when multiplying by 10. 
+            This app uses Astro, with SolidJS for state management, and sigma.js for the diagram.
+        </p>
+    </section>
+    <section>
+        <h2>What did I accomplish?</h2>
+        <ul>
+            <li>Created a directional graph that shows how the remainder for every number before the divisor changes when multiplied by 10.</li>
+            <li>Updated the graph when users updated the divisor using the controls above.</li>
+            <li>Created an explanation page for what the graph is doing and how to use it.</li>
+        </ul>
+    </section>
+</ProjectDetailsLayout>

--- a/src/pages/projects/GodotGame.astro
+++ b/src/pages/projects/GodotGame.astro
@@ -1,0 +1,18 @@
+---
+import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
+---
+<ProjectDetailsLayout title="Godot Game" imagePath="/Portfolio/Godot.png">
+    <div>
+        <h2>What is the project?</h2>
+        <p></p>
+    </div>
+    <div>
+        <h2>What did I Accomplish?</h2>
+        <p></p>
+    </div>
+    <div>
+        <h2>What's next?</h2>
+        <p></p>
+    </div>
+
+</ProjectDetailsLayout>

--- a/src/pages/projects/GodotGame.astro
+++ b/src/pages/projects/GodotGame.astro
@@ -1,7 +1,7 @@
 ---
 import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
 ---
-<ProjectDetailsLayout title="Godot Game" imagePath="/Portfolio/Godot.png">
+<ProjectDetailsLayout title="Untitled Godot Game" imagePath="/Portfolio/Godot.png" startDate={new Date(2024, 0)}>
     <div>
         <h2>What is the project?</h2>
         <p></p>

--- a/src/pages/projects/GodotGame.astro
+++ b/src/pages/projects/GodotGame.astro
@@ -2,14 +2,14 @@
 import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
 ---
 <ProjectDetailsLayout title="Untitled Godot Game" imagePath="/Portfolio/Godot.png" startDate={new Date(2024, 0)}>
-    <div>
+    <section>
         <h2>What is the project?</h2>
         <p>
             This is a board game written in C# using the Godot Engine. In it, players move along tiles on a board to complete jobs for money. 
             Players can buy tiles that they land on along the way so that other players pay rent when they land on it.
         </p>
-    </div>
-    <div>
+    </section>
+    <section>
         <h2>What did I accomplish?</h2>
         <ul>
             <li>Created tiles for job-posting and properties, which link to a number of other tiles in the map.</li>
@@ -21,12 +21,12 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
             <li>Created menus for players to trade properties and cash with each other.</li>
             <li>Created jobs, which require players to navigate around to tiles on the board to gain money.</li>
         </ul>
-    </div>
-    <div>
+    </section>
+    <section>
         <h2>What's next?</h2>
         <p>
             I am currently working on seasons and seasonal modifiers. These will be randomly selected events that are changed every few turns, and can effect player movement and rent prices.
         </p>
-    </div>
+    </section>
 
 </ProjectDetailsLayout>

--- a/src/pages/projects/GodotGame.astro
+++ b/src/pages/projects/GodotGame.astro
@@ -4,15 +4,29 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
 <ProjectDetailsLayout title="Untitled Godot Game" imagePath="/Portfolio/Godot.png" startDate={new Date(2024, 0)}>
     <div>
         <h2>What is the project?</h2>
-        <p></p>
+        <p>
+            This is a board game written in C# using the Godot Engine. In it, players move along tiles on a board to complete jobs for money. 
+            Players can buy tiles that they land on along the way so that other players pay rent when they land on it.
+        </p>
     </div>
     <div>
-        <h2>What did I Accomplish?</h2>
-        <p></p>
+        <h2>What did I accomplish?</h2>
+        <ul>
+            <li>Created tiles for job-posting and properties, which link to a number of other tiles in the map.</li>
+            <li>Created a player, which keeps track of where they are and how much value they have in cash, properties, and stocks.</li>
+            <li>Prepared player movement, allowing the player to automatically move to the next tile unless there is more than one option available.</li>
+            <li>Created districts - collections of neighboring tiles that share stock.</li>
+            <li>Created shop categories, which can be changed by the owner to influence a shop and its neighbors' rent.</li>
+            <li>Prepared wireless multiplayer, allowing multiple clients to share information between sessions.</li>
+            <li>Created menus for players to trade properties and cash with each other.</li>
+            <li>Created jobs, which require players to navigate around to tiles on the board to gain money.</li>
+        </ul>
     </div>
     <div>
         <h2>What's next?</h2>
-        <p></p>
+        <p>
+            I am currently working on seasons and seasonal modifiers. These will be randomly selected events that are changed every few turns, and can effect player movement and rent prices.
+        </p>
     </div>
 
 </ProjectDetailsLayout>

--- a/src/pages/projects/LanPartyApp.astro
+++ b/src/pages/projects/LanPartyApp.astro
@@ -15,14 +15,14 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
     <section>
         <h2>What did I accomplish?</h2>
         <ul>
-            <li>Created API to create a party</li>
-            <li>Created interface for storing locations for parties</li>
-            <li>Created API to add a user to a party</li>
-            <li>Created API to invite friend to parties</li>
-            <li>Created API for requesting a change in party location</li>
-            <li>Created optional age gate for parties</li>
-            <li>Updated styling to improve user experience on desktop</li>
-            <li>Simplified how the buttons for updating friendship statuses are shown</li>
+            <li>Created API to create a party.</li>
+            <li>Created interface for storing locations for parties.</li>
+            <li>Created API to add a user to a party.</li>
+            <li>Created API to invite friend to parties.</li>
+            <li>Created API for requesting a change in party location.</li>
+            <li>Created optional age gate for parties.</li>
+            <li>Updated styling to improve user experience on desktop.</li>
+            <li>Simplified how the buttons for updating friendship statuses are shown.</li>
         </ul>
     </section>
 

--- a/src/pages/projects/LanPartyApp.astro
+++ b/src/pages/projects/LanPartyApp.astro
@@ -1,0 +1,17 @@
+---
+import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
+
+
+---
+<ProjectDetailsLayout imagePath="/Portfolio/LanPartyApp.png" startDate={new Date(2020,8)} endDate={new Date(2020, 11, 20)} title="LAN Party App" >
+    <section>
+        <h2>What is the project?</h2>
+        <p>
+            This is a web app to help people publicise and find local in-person gaming events. This app was made with React, Node, and DynamoDB.
+            People could post about events, where they are happening, what games are to be played, and what people need to bring. 
+            People could then sign up for these events, as well as send friend requests to other accounts.
+        </p>
+    </section>
+    <section></section>
+
+</ProjectDetailsLayout>

--- a/src/pages/projects/LanPartyApp.astro
+++ b/src/pages/projects/LanPartyApp.astro
@@ -12,6 +12,18 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
             People could then sign up for these events, as well as send friend requests to other accounts.
         </p>
     </section>
-    <section></section>
+    <section>
+        <h2>What did I accomplish?</h2>
+        <ul>
+            <li>Created API to create a party</li>
+            <li>Created interface for storing locations for parties</li>
+            <li>Created API to add a user to a party</li>
+            <li>Created API to invite friend to parties</li>
+            <li>Created API for requesting a change in party location</li>
+            <li>Created optional age gate for parties</li>
+            <li>Updated styling to improve user experience on desktop</li>
+            <li>Simplified how the buttons for updating friendship statuses are shown</li>
+        </ul>
+    </section>
 
 </ProjectDetailsLayout>


### PR DESCRIPTION
# What was the Problem?
There were no details pages for the project.

# How does this Fix the Problem/
I created a project detail layout, which includes dates, an image, and a title. I  then created pages for LAN party, Godot, and Divisibility. I did not create one for Dayta, as that project does not have much to it yet.