### PR TITLE
Remove HTML extension to links in project

### DIFF
--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -8,7 +8,7 @@ import ProjectCard from "./ProjectCard.astro"
         projImage="/Portfolio/LanPartyApp.png" 
         imageAltText="LAN Party App" 
         projectName="LAN Party App" 
-        detailsLink="/Portfolio/projects/LanPartyApp.html"
+        detailsLink="/Portfolio/projects/LanPartyApp"
         startDate={new Date(2020, 8)} 
         completionDate={new Date(2020, 11)} >
         A webapp where players could create and find local game events. They could share what games are going to be played, 
@@ -19,7 +19,7 @@ import ProjectCard from "./ProjectCard.astro"
         imageAltText="Game" 
         projectName="Untitled Godot Game" 
         startDate={new Date(2024, 0)} 
-        detailsLink="/Portfolio/projects/GodotGame.html">
+        detailsLink="/Portfolio/projects/GodotGame">
         A board game video game built in Godot using C#. Players move around the board to complete jobs and buy properties for money,
         all to be the richest person in the end.
     </ProjectCard>
@@ -34,7 +34,7 @@ import ProjectCard from "./ProjectCard.astro"
         projImage="/Portfolio/DivisibilityClock.png" 
         imageAltText="Divisibility Clock" 
         projectName="Divisibility Clock" 
-        detailsLink="/Portfolio/projects/DivisibilityClock.html"
+        detailsLink="/Portfolio/projects/DivisibilityClock"
         startDate={new Date(2024, 6, 25)} 
         completionDate={new Date(2024, 6, 26)}>
         A web app that generates diagrams to represent modular arithmatic patterns. It can be found <a href="https://betonjeanette.github.io/DivisibilityClock/">by following this link</a>.


### PR DESCRIPTION
# What was the problem?
Links to project details were not working

# What does this do to Fix the Problem?
Rather than using HTML links, just use directory. The index file is created for that.