### PR TITLE
25-add-link-to-divisibility-clock-on-details-page

### DIFF
--- a/src/components/ProjectsSection.astro
+++ b/src/components/ProjectsSection.astro
@@ -40,8 +40,3 @@ import ProjectCard from "./ProjectCard.astro"
         A web app that generates diagrams to represent modular arithmatic patterns. It can be found <a href="https://betonjeanette.github.io/DivisibilityClock/">by following this link</a>.
     </ProjectCard>
 </div>
-<style>
-    a, a:visited {
-        color: var(--highlight-purple);
-    }
-</style>

--- a/src/pages/projects/DivisibilityClock.astro
+++ b/src/pages/projects/DivisibilityClock.astro
@@ -8,8 +8,11 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
         <h2>What is this project?</h2>
         <p>
             This is a web app that creates diagrams for how, for a given divisor, a number's remainder will change when multiplying by 10. 
-            This app uses Astro, with SolidJS for state management, and sigma.js for the diagram.
+            This app uses Astro, with SolidJS for state management, and sigma.js for the diagram. 
         </p>
+        <a href="https://betonjeanette.github.io/DivisibilityClock/">
+            <p>You can see it here.</p>
+        </a>
     </section>
     <section>
         <h2>What did I accomplish?</h2>
@@ -20,3 +23,8 @@ import ProjectDetailsLayout from "../../layouts/ProjectDetailsLayout.astro";
         </ul>
     </section>
 </ProjectDetailsLayout>
+<style>
+    a, a:visited {
+        color: var(--highlight-purple);
+    }
+</style>


### PR DESCRIPTION
# What was the Problem?
There was no link to the Divisibility Clock on the details page.

# How does this Fix the Problem?
I added a link to the divisibility clock. I also ensured that links on the project pages match the theme