### PR TITLE
Correct punctuation

### DIFF
--- a/src/components/ProjectCards/CarpoolCalculator.tsx
+++ b/src/components/ProjectCards/CarpoolCalculator.tsx
@@ -9,6 +9,6 @@ export default function CarpoolCalculator(){
         detailsLink="/Portfolio/projects/CarpoolCalculator">
 
         A web app that allows people to find the most efficient routes for people trying to carpool to a location. 
-        It can be found <a href="https://betonjeanette.github.io/CarpoolCalculator/">by following this link</a>
+        It can be found <a href="https://betonjeanette.github.io/CarpoolCalculator/">by following this link</a>.
     </ProjectCard>
 }


### PR DESCRIPTION
# What was the Problem?
The punctuation on the card for carpool calculator was inconsistent with the rest of the page.

# What does this do to Fix the Problem?
This adds a period to the end of the carpool calculator card.