### PR TITLE
Add Card Animation

### DIFF
--- a/src/styles/projectSection.css
+++ b/src/styles/projectSection.css
@@ -30,7 +30,8 @@
 }
 
 .cardAnimator {
-    position: absolute
+    position: absolute;
+    transition: top .0625s ease-in;
 }
 
 .projectChangeButton {


### PR DESCRIPTION
# What was the Problem?
There was no animation for the cards when flipping through them.

#What does this do to fix the problem?
The top offset now takes another pair of bools into account: if we're moving the previous card, we move the back card up before moving the rest back. If we're moving to the next card, we move the top card up before moving every other one forward.
Fixes #9