### PR TITLE
Replaced image with paragraph

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -9,7 +9,7 @@ const { iconPath } = Astro.props;
 ---
 
 <nav>
-    <a id="LogoLink" href="/Portfolio/index.html#Header"><b><img src={iconPath} alt="Jeanette Crull"  /></b></a>
+    <a id="LogoLink" href="/Portfolio/index.html#Header"><b><p>Jeanette Crull</p></b></a>
     <ul class="DestOpts">
         <NavLinks dest="/Portfolio/index.html#About" label="About" />
         <NavLinks dest="/Portfolio/index.html#ProfessionalExperience" label="Experience" />


### PR DESCRIPTION
# What was the Problem?
The main link in the nav bar for my name was an image tag, not a text tag

# Why was this a Problem?
It looked unprofessional to have a non-existing image, resulting in an icon indicating such appearing next to my name.

# What does this do to Fix the Problem?
This replaces the image tag with a paragraph tag.